### PR TITLE
Add latest version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gr8
+# Gr8 ![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.gradleup.gr8)
 
 Gr8 is [Gradle](https://gradle.org/) + [R8](https://r8.googlesource.com/r8). 
 


### PR DESCRIPTION
The readme has no link to the Plugin Portal page or an explicit version, which makes the `$agpVersion` in the usage section fairly useless. This automatically updating badge makes it easier for users to find the right version.