### PR TITLE
Prepare 0.6

### DIFF
--- a/build-logic/src/main/kotlin/gr8/PublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/gr8/PublishingPlugin.kt
@@ -21,7 +21,7 @@ class PublishingPlugin : Plugin<Project> {
 
 
       group = "com.gradleup"
-      version = "0.5"
+      version = "0.6"
 
       val projectVersion = version
 

--- a/plugin/rules.pro
+++ b/plugin/rules.pro
@@ -19,6 +19,6 @@
 
 # Makes it easier to debug on MacOS case-insensitive filesystem when unzipping the jars
 -dontusemixedcaseclassnames
--repackageclasses com.gradleup.relocated
+-repackageclasses com.gradleup.gr8.relocated
 
 

--- a/plugin/rules.pro
+++ b/plugin/rules.pro
@@ -1,6 +1,3 @@
-# The Gradle API jar isn't added to the classpath, ignore the missing symbols
--ignorewarnings
-
 # Keep kotlin metadata so that the Kotlin compiler knows about top level functions
 -keep class kotlin.Metadata { *; }
 # Keep Unit as it's in the signature of public methods:
@@ -20,8 +17,6 @@
 # Keep everything com.gradleup.** as it's being used from Gradle
 -keep class com.gradleup.** { *; }
 
-# Allow to make some classes public so that we can repackage them without breaking package-private members
--allowaccessmodification
 # Makes it easier to debug on MacOS case-insensitive filesystem when unzipping the jars
 -dontusemixedcaseclassnames
 -repackageclasses com.gradleup.relocated


### PR DESCRIPTION
- disable allowaccesmodification that causes an error when R8 tries to R8 itself
- put gr8 in the packageName
- bump version
