### PR TITLE
filter out pom files from classPathConfiguration

### DIFF
--- a/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Configurator.kt
+++ b/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Configurator.kt
@@ -158,7 +158,7 @@ open class Gr8Configurator(
 
       val classPathConfiguration = project.configurations.getByName(classPathConfiguration.get())
       classPathFiles.from(classPathConfiguration.filter {
-        !stripGradleApi || !it.isGradleApi()
+        (!stripGradleApi || !it.isGradleApi()) && !it.name.endsWith(".pom")
       })
 
       if (stripGradleApi) {

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -40,11 +40,19 @@ check(gradleTest.files.single().isGradleApi())
 
 dependencies {
   // Do not use gradleApi() as it forces Kotlin 1.4 on the classpath
-  compileOnly("dev.gradleplugins:gradle-api:6.9")
+  compileOnly("dev.gradleplugins:gradle-api:7.6") {
+    exclude("org.apache.ant")
+    exclude("org.codehaus.groovy", "groovy-swing")
+    exclude("org.codehaus.groovy", "groovy-docgenerator")
+    exclude("org.slf4j")
+  }
 
   testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
+configurations.create("gr8ClassPath") {
+  extendsFrom(configurations.getByName("compileOnly"))
+}
 
 configure<com.gradleup.gr8.Gr8Extension> {
   removeGradleApiFromApi()
@@ -52,6 +60,8 @@ configure<com.gradleup.gr8.Gr8Extension> {
   val shadowedJar = create("gr8") {
     proguardFile("rules.pro")
     configuration("runtimeClasspath")
+    classPathConfiguration("gr8ClassPath")
+    stripGradleApi(true)
   }
 
   addShadowedVariant(shadowedJar)

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.gradleup.gr8.StripGradleApiTask.Companion.isGradleApi
+import org.gradle.api.attributes.Usage.JAVA_API
 import org.w3c.dom.Element
 
 plugins {
@@ -28,19 +29,17 @@ check(gradleTest.files.single().isGradleApi())
 
 dependencies {
   // Do not use gradleApi() as it forces Kotlin 1.4 on the classpath
-  compileOnly("dev.gradleplugins:gradle-api:7.6") {
-    exclude("org.apache.ant")
-    exclude("org.codehaus.groovy", "groovy-swing")
-    exclude("org.codehaus.groovy", "groovy-docgenerator")
-    exclude("org.slf4j")
-  }
-
+  compileOnly("dev.gradleplugins:gradle-api:7.6")
+  
   testImplementation("dev.gradleplugins:gradle-test-kit:6.9")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
 configurations.create("gr8ClassPath") {
   extendsFrom(configurations.getByName("compileOnly"))
+  attributes {
+    attribute(Usage.USAGE_ATTRIBUTE, objects.named(JAVA_API))
+  }
 }
 
 configure<com.gradleup.gr8.Gr8Extension> {

--- a/test-plugin/rules.pro
+++ b/test-plugin/rules.pro
@@ -1,6 +1,3 @@
-# The Gradle API jar isn't added to the classpath, ignore the missing symbols
--ignorewarnings
-
 # Keep kotlin metadata so that the Kotlin compiler knows about top level functions
 -keep class kotlin.Metadata { *; }
 # Keep Unit as it's in the signature of public methods:


### PR DESCRIPTION
Fixes the following error when the `classPathConfiguration` has transitive enabled and contains newer `dev.gradleplugins:gradle-api` versions
```
> Task :gr8R8Jar FAILED
Error in /Users/gabrielittner/.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy-all/3.0.13/78ef859992a2e70f496c110f331cf136caa786d8/groovy-all-3.0.13.pom:
Unsupported source file type
```

I think this could probably be more agressive and explicitly filter for `.jar` but I'm not sure if we'd maybe loose something that r8 supports.