### PR TITLE
add support for Java toolchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ For plugins that generate source code and contain a lot of package names, this m
 
 By using `R8` and [proguard rules](https://www.guardsquare.com/manual/configuration/usage), `Gr8` makes relocation more predictable and configurable.
 
+**Can I override the system classes used by `R8`, like target JDK 11 with my plugin while building on Java 17?**
+
+If you set your Java toolchain then R8 will also use the same toolchain to discover system classes:
+
+```
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+```
+
+If for some reason you want to override this explicitly:
+
+```
+gr8 {
+  val shadowedJar = create("gr8") {
+    proguardFile("rules.pro")
+    configuration("shade")
+    systemClassesToolchain {
+      languageVersion.set(JavaLanguageVersion.of(11))
+    }
+  }
+}
+```
 
 **Could I use the Gradle Worker API instead?** 
 

--- a/plugin-common/build.gradle.kts
+++ b/plugin-common/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  api("dev.gradleplugins:gradle-api:6.0")
+  api("dev.gradleplugins:gradle-api:6.7")
   implementation("net.mbonnin.r8:r8:3.4.0-dev.0")
 }
 

--- a/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Configurator.kt
+++ b/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Configurator.kt
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.jvm.toolchain.JavaCompiler
-import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.jvm.toolchain.JavaToolchainSpec
 import java.io.File

--- a/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Extension.kt
+++ b/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Extension.kt
@@ -12,12 +12,17 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDepend
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
 
-open class Gr8Extension(
+abstract class Gr8Extension(
   private val project: Project,
 ) {
 
   private val configurators = mutableSetOf<String>()
+
+  @get:Inject
+  protected abstract val javaToolchainService: JavaToolchainService
 
   /**
    * @return a provider that returns the new fat-minimized jar
@@ -27,7 +32,7 @@ open class Gr8Extension(
       "Gr8: $name is already created"
     }
 
-    val configurator = Gr8Configurator(name, project)
+    val configurator = Gr8Configurator(name, project, javaToolchainService)
     configurators.add(name)
 
     action.execute(configurator)

--- a/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Task.kt
+++ b/plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Task.kt
@@ -5,13 +5,14 @@ import com.android.tools.r8.JdkClassFileProvider
 import com.android.tools.r8.OutputMode
 import com.android.tools.r8.R8
 import com.android.tools.r8.R8Command
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.*
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.internal.jvm.Jvm
-import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaCompiler
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.jvm.toolchain.JavaToolchainSpec
 import java.io.File
@@ -37,7 +38,7 @@ abstract class Gr8Task : DefaultTask() {
 
   @get:Nested
   @get:Optional
-  internal abstract val javaLauncher: Property<JavaLauncher>
+  internal abstract val javaCompiler: Property<JavaCompiler>
 
   @get:Inject
   protected abstract val javaToolchainService: JavaToolchainService
@@ -62,14 +63,14 @@ abstract class Gr8Task : DefaultTask() {
     mapping.disallowChanges()
   }
 
-  fun javaLauncher(launcher: JavaLauncher) {
-    javaLauncher.set(launcher)
-    javaLauncher.disallowChanges()
+  fun javaLauncher(launcher: JavaCompiler) {
+    javaCompiler.set(launcher)
+    javaCompiler.disallowChanges()
   }
 
-  fun toolchain(toolchain: JavaToolchainSpec) {
-    javaLauncher.set(javaToolchainService.launcherFor(toolchain))
-    javaLauncher.disallowChanges()
+  fun toolchain(spec: Action<JavaToolchainSpec>) {
+    javaCompiler.set(javaToolchainService.compilerFor(spec))
+    javaCompiler.disallowChanges()
   }
 
   fun outputJar(): Provider<RegularFile> = outputJar
@@ -105,8 +106,8 @@ abstract class Gr8Task : DefaultTask() {
           }
         }
         .apply {
-          if (javaLauncher.isPresent) {
-            val javaHome = javaLauncher.get().metadata.installationPath.asFile.toPath()
+          if (javaCompiler.isPresent) {
+            val javaHome = javaCompiler.get().metadata.installationPath.asFile.toPath()
             addLibraryResourceProvider(JdkClassFileProvider.fromJdkHome(javaHome))
           } else {
             addLibraryResourceProvider(JdkClassFileProvider.fromJdkHome(Jvm.current().javaHome.toPath()))

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
     // Because we only allow stripping the gradleApi from the classpath, we remove
     exclude("dev.gradleplugins", "gradle-api")
   }
-  compileOnly("dev.gradleplugins:gradle-api:6.0")
-  add("gr8Classpath", "dev.gradleplugins:gradle-api:6.0") {
+  compileOnly("dev.gradleplugins:gradle-api:6.7")
+  add("gr8Classpath", "dev.gradleplugins:gradle-api:6.7") {
     exclude("org.apache.ant")
   }
 }


### PR DESCRIPTION
Add support for specifying the Java toolchain to use for the R8 invoke.
The `JAVA_HOME` of the specified toolchain will be passed in to the R8 invoke as library jars. If no `toolchain` is specified then the default one from Java plugin extension is used.

NOTE: requires bumping Gradle api to 6.7, potentially breaking change for downstream consumers?